### PR TITLE
🚑 クライアントより送信されるjoinメッセージの削除　

### DIFF
--- a/app/actors/ChatActor.java
+++ b/app/actors/ChatActor.java
@@ -70,7 +70,7 @@ public class ChatActor extends AbstractActor {
                             }
                         break;
                     default:
-                        throw new IllegalAccessException("Unknown message type");
+                        throw new IllegalAccessException("Unknown message type: "+ messageType);
                     }
 
                 })


### PR DESCRIPTION
chat.jsのsocket.onopen時にメッセージが送信される処理を削除。

#8 